### PR TITLE
Markdown link checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/*
 package-lock.json
 temp
 *.log
+.vscode/launch.json

--- a/javascript/commands/cmd_markdownalert.js
+++ b/javascript/commands/cmd_markdownalert.js
@@ -1,0 +1,37 @@
+"use strict";
+const {os, request, Skarm, Constants, Web, Users, Guilds, Permissions, Skinner, SarGroups, ShantyCollection} = require("./_imports.js");
+
+module.exports = {
+        aliases: ["markdownalert"],
+        params: ["enable|disable"],
+        usageChar: "@",
+        helpText: "Toggles enabling/disabling skarm automatically responding in the channel about messages when they contain deceptive markdown links. For example, [google.com](https://xkcd.com/908/). This command is only usable by users with kicking boots. This toggle applies to the entire server. This feature is enabled by default.",
+        examples: [
+            {command: "e@markdownalert", effect: "Will report whether or not alerts are enabled."},
+            {command: "e@markdownalert enable", effect: "Will enable alerts."},
+            {command: "e@markdownalert disable", effect: "Will disable alerts."}
+        ],
+        ignoreHidden: true,
+        perms: Permissions.MOD,
+        category: "administrative",
+
+        execute(bot, e, userData, guildData) {
+            let tokens = Skarm.commandParamTokens(e.message.content);
+            let channel = e.message.channel;
+
+            if(tokens.length && tokens[0].toLowerCase() === "enable"){
+                guildData.deceptiveMarkdownLinkAlert = true;
+            }
+
+            if(tokens.length && tokens[0].toLowerCase() === "disable"){
+                guildData.deceptiveMarkdownLinkAlert = false;
+            }
+
+            Skarm.sendMessageDelay(channel, `Message alerts for suspicious markdown links are ${guildData.deceptiveMarkdownLinkAlert ? "enabled" : "disabled"}.`);
+        },
+        
+        help(bot, e) {
+            Skarm.help(this, e);
+        },
+}
+

--- a/javascript/guild.js
+++ b/javascript/guild.js
@@ -77,6 +77,7 @@ const linkVariables = function(guild) {
     guild.parrot ??= new Parrot(guild.id);
     guild.autoPin ??= new AutoPin(guild.id);
     guild.shantyIterator = new ShantyIterator(guild.shantyIterator);
+    guild.deceptiveMarkdownLinkAlert ??= true;
 };
 
 // since de/serialized objects don't keep their functions

--- a/javascript/skarm.js
+++ b/javascript/skarm.js
@@ -608,6 +608,11 @@ class Skarm {
         }
     }
 
+    static ContainsUrl(string){
+        let urlRegex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
+        return string && string.match(urlRegex);
+    }
+
     static extractGUIDs = function (message) {
         let regex = /\d+/g; // all sequences of integers (potential channel IDs)
         return [...message.matchAll(regex)].map(entry => entry[0]);


### PR DESCRIPTION
This PR adds the feature to warn channels in a server if a message with a suspicious looking link is included.  Specifically, messages that attempt to conceal a scammer's URL behind a legitimate-looking link by using Markdown of the form `[legitLink](scamLink)` are targeted.  Skarm will send an alert message if this format is seen in a message.

As a safety feature, this is on by default and the command to disable this feature is included each time skarm creates this alert.

Example:
![image](https://github.com/DragoniteSpam/SkarmBot/assets/36687789/06846bf1-e446-43d1-9789-5139c6a3ac9a)
Disabling the feature requires a moderator to run the command:
![image](https://github.com/DragoniteSpam/SkarmBot/assets/36687789/f273ad1f-ad6e-4be8-82c8-50e052150c35)
