### PR TITLE
Comic reruns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 temp
 *.log
 .vscode/launch.json
+work_chronicles.json

--- a/javascript/comics.js
+++ b/javascript/comics.js
@@ -4,7 +4,7 @@
  * Comics
  * 
  * An intermediate interface like Commands 
- * that allows for scalable onboarding of many puzzle classes
+ * that allows for scalable onboarding of many comic classes
  */
 
 const fs = require("fs");

--- a/javascript/comics.js
+++ b/javascript/comics.js
@@ -10,59 +10,61 @@
 const fs = require("fs");
 
 class ComicsCollection {
-    constructor (bot) {
-        this.comicClasses = { };
-        this.comics = { };
-        this.signatures = [ ];
+    static initialize (bot) {
+        ComicsCollection.comicClasses = { };
+        ComicsCollection.comics = { };
+        ComicsCollection.signatures = [ ];
         let dir = fs.readdirSync("./javascript/notificationServices/")
                     .filter(filename => filename[0] != "_")
                     .map(f => f.split(".")[0]);
         
         for (let file of dir) {
-            this.comicClasses[file] = require("./notificationServices/" + file);
-            this.comics[file] = new this.comicClasses[file](bot);
-            let signature = this.comics[file].signature;
+            ComicsCollection.comicClasses[file] = require("./notificationServices/" + file);
+            ComicsCollection.comics[file] = new ComicsCollection.comicClasses[file](bot);
+            let signature = ComicsCollection.comics[file].signature;
             console.log(`Initialized comic: ${file} (${signature})`);
-            this.signatures.push(signature);
+            ComicsCollection.signatures.push(signature);
         }
 
-        console.log(`Initialized ${Object.keys(this.comicClasses).length} notification services.`);
+        console.log(`Initialized ${Object.keys(ComicsCollection.comicClasses).length} notification services.`);
+        return ComicsCollection;
     }
 
-    getAvailableSubscriptions() {
-        return this.signatures;
+    static getAvailableSubscriptions() {
+        return ComicsCollection.signatures;
     }
 
-    get (target) {
-        return this.comics[target];
+    static get (target) {
+        // console.log("Requested", target, "from comics collection:", Object.keys(ComicsCollection.comics));
+        return ComicsCollection.comics[target];
     }
 
-    poll (target=undefined) {
-        let comic = this.get(target);
+    static poll (target=undefined) {
+        let comic = ComicsCollection.get(target);
         if(comic) {
             comic._poll();
         } else {
-            for(let c in this.comics){
-                this.comics[c]._poll();
+            for(let c in ComicsCollection.comics){
+                ComicsCollection.comics[c]._poll();
             }
         }
     }
 
-    poisonPill (target = undefined) {
+    static poisonPill (target = undefined) {
         if(target) {
-            return this.comics[target].poisonPill();
+            return ComicsCollection.comics[target].poisonPill();
         }
-        for (let comic in this.comics) {
-            this.comics[comic].poisonPill();
+        for (let comic in ComicsCollection.comics) {
+            ComicsCollection.comics[comic].poisonPill();
         }
     }
 
-    save (target = undefined) {
+    static save (target = undefined) {
         if(target) {
-            return this.comics[target].save();
+            return ComicsCollection.comics[target].save();
         }
-        for (let comic in this.comics) {
-            this.comics[comic].save();
+        for (let comic in ComicsCollection.comics) {
+            ComicsCollection.comics[comic].save();
         }
     }
 }

--- a/javascript/commands/cmd_Comics.js
+++ b/javascript/commands/cmd_Comics.js
@@ -23,22 +23,20 @@ module.exports = {
         execute(bot, e, userData, guildData) {
             let comicCollection = bot.comics;
             let topics = comicCollection.getAvailableSubscriptions();
-            let notifChannels = guildData.comicChannels;
             let args = Skarm.commandParamTokens(e.message.content);
-
 
             for(let i in topics) {
                 let comicName = topics[i];
-                notifChannels[comicName] ??= { };  // make sure all comic channel lists exist before accessing them
+                guildData.comicChannels[comicName] ??= { };  // make sure all comic channel lists exist before accessing them
             }
 
             function constructStatusBody() {
                 let body = "";
                 for(let i in topics) {
                     let comicName = topics[i];
-                    body += `[${i}] **${comicName}** posts are currently set to: **${(e.message.channel.id in notifChannels[comicName]) ? "Enabled":"Disabled"}**\n`;
+                    body += `[${i}] **${comicName}** posts are currently set to: **${(e.message.channel.id in guildData.comicChannels[comicName]) ? "Enabled":"Disabled"}**\n`;
                 }
-                // console.log("Notification channels:", notifChannels);
+                // console.log("Notification channels:", guildData.comicChannels);
                 // console.log("Current comic topics:", topics);
                 return body;
             }
@@ -60,13 +58,13 @@ module.exports = {
                 Skarm.sendMessageDelay(e.message.channel, `Invalid input: \`${idx}\``);
                 return;
             }
-            
+
             let topic = topics[idx];
-            if (e.message.channel.id in notifChannels[topic]) {
-                delete notifChannels[topic][e.message.channel.id];
+            if (e.message.channel.id in guildData.comicChannels[topic]) {
+                delete guildData.comicChannels[topic][e.message.channel.id];
                 Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will no longer be sent to **${e.message.channel.name}!**`);
             }else{
-                notifChannels[topic][e.message.channel.id] = Date.now();
+                guildData.comicChannels[topic][e.message.channel.id] = Date.now();
                 Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will be sent to **${e.message.channel.name}!**`);
             }
         },

--- a/javascript/commands/cmd_Comics.js
+++ b/javascript/commands/cmd_Comics.js
@@ -1,5 +1,7 @@
 "use strict";
+const ComicsCollection = require("../comics.js");
 const { os, request, Skarm, Constants, Web, Users, Guilds, Permissions, Skinner, SarGroups, ShantyCollection } = require("./_imports.js");
+ComicsCollection.initialize();
 
 module.exports = {
     aliases: ["comics"],
@@ -8,33 +10,37 @@ module.exports = {
     helpText: [
         "Toggles the notifications of comic strips for this channel.",
         "Use without a number input to view current state of channel.",
-        "Use the parameter -s (starting point) to indicate an alternative point from which skarm should start publishing comics.",
+        "Specifying another number will indicate an alternative point from which skarm should start publishing comics.",
         "Once the early start point catches up with the current release, skarm will switch to just publishing new releases."
     ].join("\n"),
     examples: [
         { command: "e@comics", effect: "Will cause Skarm to list all available comic subscriptions to toggle." },
         { command: "e@comics 1", effect: "Will cause Skarm to toggle announcing all new releases of comic 1 from the list." },
-        { command: "e@comics 1 -s 0", effect: "Starts the comic subscription feed at entry 0, publishing the next entry in the sequence once per day." },
+        { command: "e@comics 1 0", effect: "Starts the comic subscription feed at entry 0, publishing the next entry in the sequence once per day." },
     ],
     ignoreHidden: false,
     perms: Permissions.MOD,
     category: "administrative",
 
     execute(bot, e, userData, guildData) {
-        let comicCollection = bot.comics;
-        let topics = comicCollection.getAvailableSubscriptions();
+        let topics = ComicsCollection.getAvailableSubscriptions();
         let args = Skarm.commandParamTokens(e.message.content);
-
-        for (let i in topics) {
-            let comicName = topics[i];
-            guildData.comicChannels[comicName] ??= {};  // make sure all comic channel lists exist before accessing them
-        }
+        let subscriptions = guildData.comicSubscriptions;
 
         function constructStatusBody() {
             let body = "";
             for (let i in topics) {
                 let comicName = topics[i];
-                body += `[${i}] **${comicName}** posts are currently set to: **${(e.message.channel.id in guildData.comicChannels[comicName]) ? "Enabled" : "Disabled"}**\n`;
+                let subscription = subscriptions.get(e.message.channel.id, comicName);
+                if(subscription){
+                    if(subscription.live()){
+                        body += `[${i}] **${comicName}** posts are currently set to: **NEW RELEASES**\n`;
+                    } else {
+                        body += `[${i}] **${comicName}** posts are currently set to: **HISTORIC RELEASES** (current entry: ${subscription.index})\n`;
+                    }
+                } else {
+                    body += `[${i}] **${comicName}** posts are currently set to: **DISABLED**\n`;
+                }
             }
             // console.log("Notification channels:", guildData.comicChannels);
             // console.log("Current comic topics:", topics);
@@ -53,19 +59,35 @@ module.exports = {
             return;
         }
 
+        let variedStart = (args.length === 2);
+
         let idx = args[0];
         if (!(idx in topics)) {
             Skarm.sendMessageDelay(e.message.channel, `Invalid input: \`${idx}\``);
             return;
         }
 
-        let topic = topics[idx];
-        if (e.message.channel.id in guildData.comicChannels[topic]) {
-            delete guildData.comicChannels[topic][e.message.channel.id];
-            Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will no longer be sent to **${e.message.channel.name}!**`);
+        let comicName = topics[idx];
+        if (subscriptions.isSubscribed(e.message.channel.id, comicName)) {
+            subscriptions.unsubscribe(e.message.channel.id, comicName);
+            Skarm.sendMessageDelay(e.message.channel, `${comicName} will no longer be sent to **${e.message.channel.name}!**`);
         } else {
-            guildData.comicChannels[topic][e.message.channel.id] = Date.now();
-            Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will be sent to **${e.message.channel.name}!**`);
+            if(!variedStart){
+                // basic subscription case: new releases
+                subscriptions.subscribe(e.message.channel.id, comicName);
+                Skarm.sendMessageDelay(e.message.channel, `New releases of ${comicName} will be sent to **${e.message.channel.name}!**`);
+            } else {
+                // validate the argument
+                let startIdx = Math.floor(Number(args[1]));
+                if(!Number.isInteger(startIdx) || startIdx < 0) {
+                    Skarm.sendMessageDelay(e.message.channel, `Invalid starting point: \`${startIdx}\``);
+                    return;
+                }
+
+                // set up the catch-up subscriber
+                subscriptions.subscribeAt(e.message.channel.id, comicName, startIdx);
+                Skarm.sendMessageDelay(e.message.channel, `Releases of ${comicName} starting at ${startIdx} will be sent to **${e.message.channel.name}** daily!`);
+            }
         }
     },
 

--- a/javascript/commands/cmd_Comics.js
+++ b/javascript/commands/cmd_Comics.js
@@ -1,76 +1,76 @@
 "use strict";
-const {os, request, Skarm, Constants, Web, Users, Guilds, Permissions, Skinner, SarGroups, ShantyCollection} = require("./_imports.js");
+const { os, request, Skarm, Constants, Web, Users, Guilds, Permissions, Skinner, SarGroups, ShantyCollection } = require("./_imports.js");
 
 module.exports = {
-        aliases: ["comics"],
-        params: ["#"],
-        usageChar: "@",
-        helpText: [
-            "Toggles the notifications of comic strips for this channel.",
-            "Use without a number input to view current state of channel.",
-            "Use the parameter -s (starting point) to indicate an alternative point from which skarm should start publishing comics.",
-            "Once the early start point catches up with the current release, skarm will switch to just publishing new releases."
-        ].join("\n"),
-        examples: [
-            {command: "e@comics", effect: "Will cause Skarm to list all available comic subscriptions to toggle."},
-            {command: "e@comics 1", effect: "Will cause Skarm to toggle announcing all new releases of comic 1 from the list."},
-            {command: "e@comics 1 -s 0", effect: "Starts the comic subscription feed at entry 0, publishing the next entry in the sequence once per day."},
-        ],
-        ignoreHidden: false,
-        perms: Permissions.MOD,
-        category: "administrative",
+    aliases: ["comics"],
+    params: ["#"],
+    usageChar: "@",
+    helpText: [
+        "Toggles the notifications of comic strips for this channel.",
+        "Use without a number input to view current state of channel.",
+        "Use the parameter -s (starting point) to indicate an alternative point from which skarm should start publishing comics.",
+        "Once the early start point catches up with the current release, skarm will switch to just publishing new releases."
+    ].join("\n"),
+    examples: [
+        { command: "e@comics", effect: "Will cause Skarm to list all available comic subscriptions to toggle." },
+        { command: "e@comics 1", effect: "Will cause Skarm to toggle announcing all new releases of comic 1 from the list." },
+        { command: "e@comics 1 -s 0", effect: "Starts the comic subscription feed at entry 0, publishing the next entry in the sequence once per day." },
+    ],
+    ignoreHidden: false,
+    perms: Permissions.MOD,
+    category: "administrative",
 
-        execute(bot, e, userData, guildData) {
-            let comicCollection = bot.comics;
-            let topics = comicCollection.getAvailableSubscriptions();
-            let args = Skarm.commandParamTokens(e.message.content);
+    execute(bot, e, userData, guildData) {
+        let comicCollection = bot.comics;
+        let topics = comicCollection.getAvailableSubscriptions();
+        let args = Skarm.commandParamTokens(e.message.content);
 
-            for(let i in topics) {
+        for (let i in topics) {
+            let comicName = topics[i];
+            guildData.comicChannels[comicName] ??= {};  // make sure all comic channel lists exist before accessing them
+        }
+
+        function constructStatusBody() {
+            let body = "";
+            for (let i in topics) {
                 let comicName = topics[i];
-                guildData.comicChannels[comicName] ??= { };  // make sure all comic channel lists exist before accessing them
+                body += `[${i}] **${comicName}** posts are currently set to: **${(e.message.channel.id in guildData.comicChannels[comicName]) ? "Enabled" : "Disabled"}**\n`;
             }
+            // console.log("Notification channels:", guildData.comicChannels);
+            // console.log("Current comic topics:", topics);
+            return body;
+        }
 
-            function constructStatusBody() {
-                let body = "";
-                for(let i in topics) {
-                    let comicName = topics[i];
-                    body += `[${i}] **${comicName}** posts are currently set to: **${(e.message.channel.id in guildData.comicChannels[comicName]) ? "Enabled":"Disabled"}**\n`;
-                }
-                // console.log("Notification channels:", guildData.comicChannels);
-                // console.log("Current comic topics:", topics);
-                return body;
-            }
+        constructStatusBody();
 
-            constructStatusBody();
+        if (args.length === 0) {
+            Skarm.sendMessageDelay(e.message.channel, " ", false, {
+                color: Constants.Colors.BLUE,
+                author: { name: e.message.author.nick },
+                description: `Configure notification settings for <#${e.message.channel.id}>:\r\n\r\n` + constructStatusBody(),
+                timestamp: new Date(),
+            });
+            return;
+        }
 
-            if (args.length === 0) {
-                Skarm.sendMessageDelay(e.message.channel, " ",false,{
-                    color: Constants.Colors.BLUE,
-                    author: {name: e.message.author.nick},
-                    description: `Configure notification settings for <#${e.message.channel.id}>:\r\n\r\n`+ constructStatusBody(),
-                    timestamp: new Date(),
-                });
-                return;
-            }
+        let idx = args[0];
+        if (!(idx in topics)) {
+            Skarm.sendMessageDelay(e.message.channel, `Invalid input: \`${idx}\``);
+            return;
+        }
 
-            let idx = args[0];
-            if (!(idx in topics)) {
-                Skarm.sendMessageDelay(e.message.channel, `Invalid input: \`${idx}\``);
-                return;
-            }
+        let topic = topics[idx];
+        if (e.message.channel.id in guildData.comicChannels[topic]) {
+            delete guildData.comicChannels[topic][e.message.channel.id];
+            Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will no longer be sent to **${e.message.channel.name}!**`);
+        } else {
+            guildData.comicChannels[topic][e.message.channel.id] = Date.now();
+            Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will be sent to **${e.message.channel.name}!**`);
+        }
+    },
 
-            let topic = topics[idx];
-            if (e.message.channel.id in guildData.comicChannels[topic]) {
-                delete guildData.comicChannels[topic][e.message.channel.id];
-                Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will no longer be sent to **${e.message.channel.name}!**`);
-            }else{
-                guildData.comicChannels[topic][e.message.channel.id] = Date.now();
-                Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will be sent to **${e.message.channel.name}!**`);
-            }
-        },
-
-        help(bot, e) {
-            Skarm.help(this, e);
-        },
+    help(bot, e) {
+        Skarm.help(this, e);
+    },
 }
 

--- a/javascript/commands/cmd_Comics.js
+++ b/javascript/commands/cmd_Comics.js
@@ -5,10 +5,16 @@ module.exports = {
         aliases: ["comics"],
         params: ["#"],
         usageChar: "@",
-        helpText: "Toggles the notifications of comic strips for this channel.  Use without a number input to view current state of channel.",
+        helpText: [
+            "Toggles the notifications of comic strips for this channel.",
+            "Use without a number input to view current state of channel.",
+            "Use the parameter -s (starting point) to indicate an alternative point from which skarm should start publishing comics.",
+            "Once the early start point catches up with the current release, skarm will switch to just publishing new releases."
+        ].join("\n"),
         examples: [
             {command: "e@comics", effect: "Will cause Skarm to list all available comic subscriptions to toggle."},
             {command: "e@comics 1", effect: "Will cause Skarm to toggle announcing all new releases of comic 1 from the list."},
+            {command: "e@comics 1 -s 0", effect: "Starts the comic subscription feed at entry 0, publishing the next entry in the sequence once per day."},
         ],
         ignoreHidden: false,
         perms: Permissions.MOD,
@@ -50,19 +56,19 @@ module.exports = {
             }
 
             let idx = args[0];
-            if (idx in topics) {
-                let topic = topics[idx];
-                if (e.message.channel.id in notifChannels[topic]) {
-                    delete notifChannels[topic][e.message.channel.id];
-                    Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will no longer be sent to **${e.message.channel.name}!**`);
-                }else{
-                    notifChannels[topic][e.message.channel.id] = Date.now();
-                    Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will be sent to **${e.message.channel.name}!**`);
-                }
+            if (!(idx in topics)) {
+                Skarm.sendMessageDelay(e.message.channel, `Invalid input: \`${idx}\``);
                 return;
             }
-
-            Skarm.sendMessageDelay(e.message.channel, `Invalid input: \`${idx}\``);
+            
+            let topic = topics[idx];
+            if (e.message.channel.id in notifChannels[topic]) {
+                delete notifChannels[topic][e.message.channel.id];
+                Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will no longer be sent to **${e.message.channel.name}!**`);
+            }else{
+                notifChannels[topic][e.message.channel.id] = Date.now();
+                Skarm.sendMessageDelay(e.message.channel, `New releases of ${topic} will be sent to **${e.message.channel.name}!**`);
+            }
         },
 
         help(bot, e) {

--- a/javascript/guildClasses/comicSubscriptions.js
+++ b/javascript/guildClasses/comicSubscriptions.js
@@ -23,7 +23,7 @@ class Subscription {
         if (!this.live()) {
             console.log("Set up catch-up publisher for comic:", this.channel, this.comic);
             let tis = this;
-            this.interval = setInterval(()=>{tis.postCatchup();}, 1 * Constants.Time.DAYS);
+            this.interval = setInterval(() => { tis.postCatchup(); }, 1 * Constants.Time.DAYS);
         }
     }
 
@@ -32,7 +32,7 @@ class Subscription {
         if (this.live()) return;
 
         let comic = ComicsCollection.get(this.comic);
-        if(!comic){
+        if (!comic) {
             console.log("Failed to retrieve comic", this.comic, "from comic collection.  Got:", comic);
             return;
         }
@@ -127,7 +127,7 @@ class ComicSubscriptions {
 
     unsubscribe(channel, comic) {
         let unsub = this.get(channel, comic);
-        if(unsub.interval){
+        if (unsub.interval) {
             clearInterval(unsub.interval);
         }
 

--- a/javascript/guildClasses/comicSubscriptions.js
+++ b/javascript/guildClasses/comicSubscriptions.js
@@ -1,0 +1,72 @@
+"use strict";
+const fs = require("fs");
+const Skarm = require("../skarm.js");
+const Constants = require("../constants.js");
+
+class Subscription {
+    /**
+     * An instance of a subscription object, tracking a comic-channel pair and their tracking configuration 
+     * @param {string} channelID The channel to send comics to
+     * @param {string} comic Which comic (by name) the subscription is made to
+     * @param {int} index The position in the comics list of this entry. 
+     *                    The value -1 indicates a live subscription feed.  
+     *                    Not specifying the parameter will use the default live subscription.
+     */
+    constructor(channel, comic, index = -1) {
+        this.channel = channel;
+        this.comic = comic;
+        this.index = index;
+    }
+
+    live() {
+        // indicates if the subscription is to live releases
+        // true  --> only notify about new releases
+        // false --> post daily entries until caught up to live
+        return (index === -1);
+    }
+
+    equals(other) {
+        // check if two subscriptions are the same channel+comic pair
+        if (this.channel !== other.channel) return false;
+        if (this.comic !== other.comic) return false;
+        return true;
+    }
+}
+
+class ComicSubscriptions {
+    constructor(oldChannels, self) {
+        this.subscriptions = [];
+
+        // import legacy properties
+        if (oldChannels) {
+            for (let comic in oldChannels) {
+                let channels = Object.keys(oldChannels[comic]);
+                for (let channelID of channels) {
+                    this.subscriptions.push(new Subscription(channelID, comic));
+                }
+            }
+        }
+
+        // merge with self
+        if (self) {
+            for (let sub of self.subscriptions) {
+                this.subscriptions.push(new Subscription(sub.channel, sub.comic, sub.index));
+            }
+        }
+    }
+
+    notify(client, comicClass, publishingData) {
+        console.log("Comic channels for guild:", guild.id, guild.comicChannels);
+        this.subscriptions
+            .filter(sub => sub.comic === comicClass) // publish just this comic class
+            .filter(sub => sub.live())             // finding all the subscriptions to the live release only
+            .map((sub) => {
+                Skarm.spam(`Sending ${comicClass} message to <#${sub.channel}>`);
+                Skarm.sendMessageDelay(client.Channels.get(sub.channel), publishingData);
+            });
+    }
+}
+
+module.exports = {
+    ComicSubscriptions
+}

--- a/javascript/notificationServices/WorkChronicles.js
+++ b/javascript/notificationServices/WorkChronicles.js
@@ -70,26 +70,24 @@ class WorkChronicles extends ComicNotifier {
 
 	post(channel, id) {
 		if (!this.enabled) return;
-		id = id || "";
-
-		if (id === "") {
+		if(!id && id != 0){
 			Skarm.sendMessageDelay(channel, "No comic specified");
+			console.log("empty ID field");
+			Skarm.spam("empty ID field");
 			return;
+		}
+
+		if(Math.floor(id) in this.comicArchive){
+			Skarm.sendMessageDelay(channel, this.comicArchive[id].cover_image);
+			return;
+		} else {
+			console.log("ID", id, "was not in the comic archive", Object.keys(this), Object.keys(this.comicArchive));
 		}
 
 		let results = [];
 
-		for (let reference in this.comicArchive) {
-			// halt on exact matches
-			if (reference === id) {
-				results = [{ reference: reference, link: this.comicArchive[reference] }];
-				break;
-			}
+		// todo: name-based matching
 
-			if (reference.includes(id)) {
-				results.push({ reference: reference, link: this.comicArchive[reference] });
-			}
-		}
 
 		if (results.length === 0) {
 			Skarm.sendMessageDelay(channel, "I couldn't find any work chronicles containing **" + id + "** in the title\nヽ( ｡ ヮﾟ)ノ");

--- a/javascript/notificationServices/WorkChronicles.js
+++ b/javascript/notificationServices/WorkChronicles.js
@@ -35,22 +35,22 @@ class WorkChronicles extends ComicNotifier {
 			// seek out the new ones from the response
 			comics = comics.filter(c => c.title.includes("(comic)"));
 			console.log("Received", comics.length, "results from", target);
-			for(let fullComicObj of comics){
-				
+			for (let fullComicObj of comics) {
+
 				// reduce the object down to just these properties for saving
 				let { title, slug, post_date, canonical_url, cover_image } = fullComicObj;
-				let smallC = { title, slug, post_date, canonical_url, cover_image }; 
+				let smallC = { title, slug, post_date, canonical_url, cover_image };
 
 				// check if we already have an entry with that slug
-				let existingC = tis.comicArchive.filter(entry=>entry.slug === smallC.slug);
-				if(existingC.length > 0) continue; // don't republish existing comics
+				let existingC = tis.comicArchive.filter(entry => entry.slug === smallC.slug);
+				if (existingC.length > 0) continue; // don't republish existing comics
 				console.log("Found new comic:", smallC);
 
 				// add the comic to the collection
 				tis.comicArchive.push(smallC);
 
 				// make sure things remain sorted by publication date
-				tis.comicArchive.sort((a,b) => {
+				tis.comicArchive.sort((a, b) => {
 					let ad = (new Date(a.post_date)).getTime();
 					let bd = (new Date(b.post_date)).getTime();
 					let comparison = ad - bd;
@@ -70,14 +70,14 @@ class WorkChronicles extends ComicNotifier {
 
 	post(channel, id) {
 		if (!this.enabled) return;
-		if(!id && id != 0){
+		if (!id && id != 0) {
 			Skarm.sendMessageDelay(channel, "No comic specified");
 			console.log("empty ID field");
 			Skarm.spam("empty ID field");
 			return;
 		}
 
-		if(Math.floor(id) in this.comicArchive){
+		if (Math.floor(id) in this.comicArchive) {
 			Skarm.sendMessageDelay(channel, this.comicArchive[id].cover_image);
 			return;
 		} else {

--- a/javascript/notificationServices/_comic_base_class.js
+++ b/javascript/notificationServices/_comic_base_class.js
@@ -101,7 +101,7 @@ class ComicNotifier {
 		for(let guild in Guild.guilds) {
 			setTimeout(()=>{
 				console.log("Notifying guild", guild, "of new release:", publishingData);
-				Guild.guilds[guild].comicNotify(tis.bot.client, tis.signature, publishingData);
+				Guild.guilds[guild].comicSubscriptions.notify(tis.bot.client, tis.signature, publishingData);
 			}, tis.discoveryDelay_ms);
 		}
 		tis.save(Constants.SaveCodes.DONOTHING);

--- a/javascript/notificationServices/_comic_base_class.js
+++ b/javascript/notificationServices/_comic_base_class.js
@@ -31,7 +31,11 @@ class ComicNotifier {
 
 	length () {
 		// Returns the number of comics currently in the collection
-		return Object.keys(this.comicArchive).length;
+		if(Array.isArray(this.comicArchive)){
+			return this.comicArchive.length;
+		} else {
+			return Object.keys(this.comicArchive).length;
+		}
 	}
 
 	createComicArchive () {

--- a/javascript/notificationServices/xkcd.js
+++ b/javascript/notificationServices/xkcd.js
@@ -58,6 +58,7 @@ class XKCD extends ComicNotifier {
 
 	post(channel, id) {
 		if (!this.enabled) return;
+		if(Number.isInteger(id)){id = `${id}`;} // cast int -> str
 		id = (id || "").toLowerCase();
 		if (id.match(/^\d+$/)) {
 			Skarm.sendMessageDelay(channel, "https://xkcd.com/" + id + "/");

--- a/javascript/skarm.js
+++ b/javascript/skarm.js
@@ -108,6 +108,9 @@ class Skarm {
             return;
         }
 
+        // debugging
+        // console.log("evaluating permissions for channel", channel);
+
         let requiredTextPermissions = [
             "READ_MESSAGES",
             "SEND_MESSAGES"

--- a/javascript/skarmbot.js
+++ b/javascript/skarmbot.js
@@ -44,7 +44,7 @@ class Bot {
 
         this.shanties = new ShantyCollection();
 
-        this.comics = new ComicsCollection(this);
+        this.comics = ComicsCollection.initialize(this);
 
         /**
          * keeps a short lifespan cache of messages sent by skarm which are going to be deleted,

--- a/launcher.ps1
+++ b/launcher.ps1
@@ -64,12 +64,11 @@ if ($operationMode -eq "live") {
 }
 
 
+# no persistence through failures during testing
 if ($operationMode -eq "test") {
-    do {
-        node $PSScriptRoot\bot.js
-        $LEC = $LASTEXITCODE
-        Write-Host "Process exited with code $LEC"
-    }while ($LEC -ne 0 -and $LEC -ne 42)
+    node $PSScriptRoot\bot.js
+    $LEC = $LASTEXITCODE
+    Write-Host "Process exited with code $LEC"
 }
 
 Pop-Location


### PR DESCRIPTION
This PR adds the ability to subscribe to historic comics to catch up to the live content on a daily basis.  Example usage in the screenshots.

![image](https://github.com/user-attachments/assets/8f8a9c8d-5749-4466-a172-fc941501ad2a)

Once the historic releases have caught up to the latest release, the subscription will automatically switch from historic to new release mode.