### PR TITLE
Birthday Announcement Backend

### DIFF
--- a/javascript/commands/cmd_BdayAnnounce.js
+++ b/javascript/commands/cmd_BdayAnnounce.js
@@ -1,0 +1,72 @@
+"use strict";
+const { os, request, Skarm, Constants, Web, Users, Guilds, Permissions, Skinner, SarGroups, ShantyCollection } = require("./_imports.js");
+
+module.exports = {
+    aliases: ["birthdayannouncements", "bda"],
+    params: ["enable", "disable", "list", "count"],
+    usageChar: "@",
+    helpText: [
+        "Configures skarm to announce the birthdays of current members."
+    ].join("\n"),
+    examples: [
+        { command: "e@birthdayannouncements enable", effect: "Configures skarm to announce birthdays in **this channel**" },
+        { command: "e@bda", effect: "Indicates if this channel will announce birthdays" },
+        { command: "e@bda enable", effect: "Configures skarm to announce birthdays in **this channel**" },
+        { command: "e@bda disable", effect: "Turns off announcement of birthdays in **this channel**.  Announcements in other channels are unaffected." },
+        { command: "e@bda list", effect: "Lists all channels in this server that will announce birthdays (in case multiple are configured)" },
+        { command: "e@bda count", effect: "Provides a count of how many users have allowed skarm to announce their birthday in this server" },
+        { command: "e@bda announce", effect: "Sends the announcement ahead of skarm's automated schedule for the day!" },
+    ],
+    ignoreHidden: false,
+    perms: Permissions.MOD,
+    category: "administrative",
+
+    execute(bot, e, userData, guildData) {
+        let cmd = Skarm.commandParamString(e.message.content);
+        let bda = guildData.birthdayAnnouncer;
+        let channel = e.message.channel;
+        let success;
+        switch (cmd) {
+            case "enable":
+            case "e":
+                success = bda.enable(channel.id);
+                if (success) {
+                    Skarm.sendMessageDelay(channel, "I'll announce birthdays in this channel!");
+                } else {
+                    Skarm.sendMessageDelay(channel, "This channel is already configured to announce birthdays!");
+                }
+                break;
+
+            case "disable":
+            case "d":
+                bda.disable(channel.id);
+                Skarm.sendMessageDelay(channel, "Birthday announcements disabled in this channel!");
+                break;
+
+            case "list":
+            case "l":
+            case "":
+                if (bda.channels.length > 0) {
+                    Skarm.sendMessageDelay(channel, `Birthday announcements will be sent to: ${bda.channels.map(ch => `<#${ch}>`).join(" ")}`);
+                } else {
+                    Skarm.sendMessageDelay(channel, "Birthday announcements aren't being sent to any channels!");
+                }
+                break;
+
+            case "count":
+            case "c":
+                Skarm.sendMessageDelay(channel, `I'll announce the birthdays of ${bda.getEnabledMembers().length} server members!`);
+                break;
+
+            case "announce":
+                bda.announce();
+                break;
+        }
+
+    },
+
+    help(bot, e) {
+        Skarm.help(this, e);
+    },
+}
+

--- a/javascript/guild.js
+++ b/javascript/guild.js
@@ -14,6 +14,7 @@ const AutoPin = require("./guildClasses/autopin.js");
 const {Zipf} = require("./guildClasses/zipf.js");
 const { ComicSubscriptions } = require("./guildClasses/comicSubscriptions.js");
 const { AnonymousPoll } = require("./guildClasses/anonymousPoll.js");
+const BirthdayAnnouncer = require("./guildClasses/BirthdayAnnouncer.js");
 
 
 const guilddb = "../skarmData/guilds.penguin";
@@ -64,6 +65,7 @@ const linkVariables = function(guild) {
     // regenerate the object from previously serialized data
     guild.shantyIterator = new ShantyIterator(guild.shantyIterator);
     guild.anonPoll = new AnonymousPoll(guild.anonPoll);
+    guild.birthdayAnnouncer = new BirthdayAnnouncer(guild.birthdayAnnouncer, guild.id);
 
     guild.zipf = new Zipf(guild.zipfMap, guild.zipf);
     if(guild.zipfMap) delete guild.zipfMap;

--- a/javascript/guildClasses/BirthdayAnnouncer.js
+++ b/javascript/guildClasses/BirthdayAnnouncer.js
@@ -1,0 +1,113 @@
+/**
+ * Birthday announcer
+ */
+
+"use strict";
+const Skarm = require("../skarm.js");
+const Constants = require("../constants.js");
+const Permissions = require("../permissions.js");
+const Skinner = require("../skinnerbox.js");
+const User = require("../user.js");
+
+/**
+ * since classes are serialized for Guilds.save, 
+ *  setInterval cannot be attached to the object without
+ *  causing circular serialization issues.
+ * 
+ * It also doesn't need to be saved as it gets reset when skarm restarts
+ */
+let subIntervals = {};
+
+
+class BirthdayAnnouncer {
+    constructor(self, guildId) {
+        self ??= {}; // for initialization
+        this.channels = self.channels || [];  // list of channel ID's
+        this.lastRun = self.lastRun || "0000-00-00";
+        this.guildId = guildId;
+        let tis = this;
+        subIntervals[guildId] = setInterval(() => {
+            tis.announce();
+        }, 1 * Constants.Time.HOURS);  // run every hour just to make sure we cover everyone in case of an outage
+    }
+
+    enable(channelId){
+        /**
+         * @returns true if the channel was added, false if it was already present
+         */
+        if(this.channels.includes(channelId)){
+            return false;
+        }
+        this.channels.push(channelId);
+        return true;
+    }
+
+    disable(channelId){
+        /**
+         * @returns true if the channel was removed, false if it wasn't there before
+         */
+        if(!this.channels.includes(channelId)){
+            return false;
+        }
+        this.channels = this.channels.filter(id => id !== channelId); // filter out the ID
+        return true;
+    }
+
+    async announce() {
+        console.log("Performing announcement cycle");
+        
+        // extract the month and day from today's date
+        let unix = Date.now() - (new Date()).getTimezoneOffset() * Constants.Time.MINUTES;
+        let today = (new Date(unix)).toISOString().split("T")[0];
+        let monthDayString = today.substring(4);
+
+        // make sure you don't run twice on the same day
+        if(! (today > this.lastRun)) {
+            // already ran today, don't need to do anything in this scenario
+            console.log("Already checked for birthdays in server", this.guildId, "skipping...");
+            return;
+        }
+
+        // find the proper members
+        let enMem = this.getEnabledMembers();
+        let members = enMem
+            .filter(sUser => sUser.birthday.includes(monthDayString));   // extract just the users whose birthday is today (matches month and day)
+        console.log(`Found ${members.length} whose birthday is today from ${enMem.length} enabled guild members!`)
+
+        // send celebratory messages
+        for (let bdMember of members) {
+            for (let channel of this.channels) {
+                await Skarm.sendMessageDelay(channel, `Happy Birthday <@${bdMember.id}>! ${this.getRandomEmojis(5)}`);
+            }
+        }
+
+        // update the last time this was done to today!
+        this.lastRun = today;
+
+    }
+
+    getEnabledMembers(){
+        let guild = Constants.client.Guilds.get(this.guildId);
+        let members = guild.members                     // get all the members in the discord guild
+            .map(member => User.get(member.id))         // match them to skarm's User class instances
+            .filter(sUser => sUser.birthday && sUser.birthdayAllowedGuilds[this.guildId]);   // extract just the ones that agreed to announce their birthdays here and have actually set a date
+        return members;
+    }
+
+    getRandomEmojis(num){
+        return (new Array(num).fill("")).map(_ => this.getRandomBdayEmoji()).join(" ");
+    }
+
+    getRandomBdayEmoji() {
+        let emojis = [
+            ":birthday:",
+            ":partying_face:",
+            ":confetti_ball:",
+            ":tada:",
+            ":sparkler:",
+        ];
+        return emojis[Math.floor(Math.random() * emojis.length)];
+    }
+}
+
+module.exports = BirthdayAnnouncer;

--- a/javascript/guildClasses/comicSubscriptions.js
+++ b/javascript/guildClasses/comicSubscriptions.js
@@ -11,9 +11,7 @@ Constants.initialize();
  *  setInterval cannot be attached to the object without
  *  causing circular serialization issues.
  */
-let subIntervals = {
-
-};
+let subIntervals = {};
 
 class Subscription {
     /**

--- a/javascript/skarmbot.js
+++ b/javascript/skarmbot.js
@@ -423,11 +423,12 @@ class Bot {
             default:
                 break;
         }
+        
 
         // gets all the guilds that this user is in, and the open polls in each one
-        let openPolls = userData.getGuilds()                    // get all guilds the user is in
-            .flatMap(g => g.anonPoll.polls.filter(p => p.open)  // filter down the polls in each of those guilds to just the ones that are open to new submissions
-                .map((p) => { return { guild: g, poll: p } })); // return pairs of guild and poll to be able to print out the source guild of each poll
+        let openPolls = userData.getGuilds().map(g => Guild.get(g)) // get all guilds the user is in
+            .flatMap(g => g.anonPoll.polls.filter(p => p.open)      // filter down the polls in each of those guilds to just the ones that are open to new submissions
+                .map((p) => { return { guild: g, poll: p } }));     // return pairs of guild and poll to be able to print out the source guild of each poll
 
         if (e.message.attachments.length === 1) {
             let receivedImage = e.message.attachments[0].url;

--- a/javascript/user.js
+++ b/javascript/user.js
@@ -4,7 +4,6 @@ const Encrypt = require("./encryption.js");
 const Skarm = require("./skarm.js");
 const Discordie = require("discordie");
 const Constants = require("./constants");
-const Guild = require("./guild.js");
 
 const userdb = "../skarmData/users.penguin";
 const SUMMON_COOLDOWN = 60000;
@@ -153,7 +152,8 @@ const linkFunctions = function(user) {
         let u = User.client.Users.get(user.id);
         return User.client.Guilds
             .filter(g => u.memberOf(g))
-            .map(g => Guild.get(g.id));
+            .map(g => g.id)
+            ;
     }
 }
 


### PR DESCRIPTION
This PR implements guild tools for setting up announcements for member birthdays.  For an announcement event to happen, the following pre-requisites must be satisfied:
- members need to have already set their birthday with the command `e!birthday 2000-01-01` (substituting the ISO 8601 date for their own birthday) 
     - ISO 8601 is a soft requirement.  In practice, anything that `new Date(yourString)` will successfully parse will be fine.  For example, `e!bd Apr 1` for April 1st.
             - A goofy byproduct of JS's `new Date()` argument is that the year seems to default to `2001` if a year is not specified.  Fortunately, this doesn't defeat the point of being a yearly announcement.
- members need to have allowed this server to announce their birthday (done with `e!birthday allow`)
- A server channel needs to allow publishing these messages (enabled by the command `e@bda enable`)

Mods can optionally force announcements to arrive ahead of schedule with `e@bda announce` instead of waiting for the hourly timer.

Demo:
![image](https://github.com/user-attachments/assets/c8f43b24-b0b1-455c-bb81-a6cfe817bcdb)
![image](https://github.com/user-attachments/assets/93eaef88-b70b-4bb9-8f4b-ca0884f4aaf1)
